### PR TITLE
Enable passing of AWS Session Token in Hazelcast AWS Config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The following properties can be configured (all are optional).
 
 
 * `access-key`, `secret-key`: access and secret keys of your AWS account; if not set, `iam-role` is used
+* `session-token`: set when using temporary security credentials
 * `iam-role`: IAM Role attached to EC2 instance used to fetch credentials (if `access-key`/`secret-key` not specified); if not set, default IAM Role attached to EC2 instance is used
 * `region`: region where Hazelcast members are running; default is the current region
 * `host-header`: `ec2`, `ecs`, or the URL of a EC2/ECS API endpoint; automatically detected by default
@@ -116,6 +117,7 @@ Hazelcast Client discovery parameters are the same as mentioned above.
 
 If Hazelcast Client is run **outside AWS**, then you need to always specify the following parameters:
 - `access-key`, `secret-key` - IAM role cannot be used from outside AWS
+- `session-token` - (optional) set when using temporary security credentials
 - `region` - it cannot be detected automatically
 - `use-public-ip` - must be set to `true`
 
@@ -226,6 +228,7 @@ config.getNetworkConfig().getInterfaces().setEnabled(true).addInterface("10.0.*.
 The following properties can be configured (all are optional).
 
 * `access-key`, `secret-key`: access and secret keys of AWS your account; if not set, IAM Task Role is used
+* `session-token`: set when using temporary security credentials
 * `region`: region where Hazelcast members are running; default is the current region
 * `cluster`: ECS cluster short name or ARN; default is the current cluster
 * `family`: filter to look only for ECS tasks with the given family name; mutually exclusive with `service-name`
@@ -243,6 +246,7 @@ Hazelcast Client discovery parameters are the same as mentioned above.
 
 If Hazelcast Client is run **outside ECS cluster**, then you need to always specify the following parameters:
 - `access-key`, `secret-key` - IAM role cannot be used from outside AWS
+- `session-token` - (optional) set when using temporary credentials 
 - `region` - it cannot be detected automatically
 - `cluster` - it cannot be detected automatically
 - `use-public-ip` - must be set to `true`

--- a/src/main/java/com/hazelcast/aws/AwsConfig.java
+++ b/src/main/java/com/hazelcast/aws/AwsConfig.java
@@ -43,6 +43,7 @@ final class AwsConfig {
     private final PortRange hzPort;
     private final String accessKey;
     private final String secretKey;
+    private final String sessionToken;
     private final String iamRole;
     private final String cluster;
     private final String family;
@@ -50,12 +51,13 @@ final class AwsConfig {
 
     @SuppressWarnings("checkstyle:parameternumber")
     // Constructor has a lot of parameters, but it's private.
-    private AwsConfig(String accessKey, String secretKey, String region, String iamRole, String hostHeader,
+    private AwsConfig(String accessKey, String secretKey, String sessionToken, String region, String iamRole, String hostHeader,
                       String securityGroupName, String tagKey, String tagValue, int connectionTimeoutSeconds,
                       int connectionRetries, int readTimeoutSeconds, PortRange hzPort, String cluster, String family,
                       String serviceName) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
+        this.sessionToken = sessionToken;
         this.region = region;
         this.iamRole = iamRole;
         this.hostHeader = hostHeader;
@@ -149,6 +151,11 @@ final class AwsConfig {
         return secretKey;
     }
 
+    String getSessionToken()
+    {
+        return sessionToken;
+    }
+
     String getRegion() {
         return region;
     }
@@ -221,6 +228,7 @@ final class AwsConfig {
 
         private String accessKey;
         private String secretKey;
+        private String sessionToken;
         private String region;
         private String iamRole;
         private String hostHeader;
@@ -242,6 +250,11 @@ final class AwsConfig {
 
         Builder setSecretKey(String secretKey) {
             this.secretKey = secretKey;
+            return this;
+        }
+
+        Builder setSessionToken(String token) {
+            this.sessionToken = token;
             return this;
         }
 
@@ -311,8 +324,8 @@ final class AwsConfig {
         }
 
         AwsConfig build() {
-            return new AwsConfig(accessKey, secretKey, region, iamRole, hostHeader, securityGroupName, tagKey, tagValue,
-                connectionTimeoutSeconds, connectionRetries, readTimeoutSeconds, hzPort, cluster, family, serviceName);
+            return new AwsConfig(accessKey, secretKey, sessionToken, region, iamRole, hostHeader, securityGroupName, tagKey, tagValue,
+                    connectionTimeoutSeconds, connectionRetries, readTimeoutSeconds, hzPort, cluster, family, serviceName);
         }
     }
 }

--- a/src/main/java/com/hazelcast/aws/AwsCredentialsProvider.java
+++ b/src/main/java/com/hazelcast/aws/AwsCredentialsProvider.java
@@ -74,6 +74,7 @@ class AwsCredentialsProvider {
             return AwsCredentials.builder()
                 .setAccessKey(awsConfig.getAccessKey())
                 .setSecretKey(awsConfig.getSecretKey())
+                .setToken(awsConfig.getSessionToken())
                 .build();
         }
         if (StringUtils.isNotEmpty(ec2IamRole)) {

--- a/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/aws/AwsDiscoveryStrategy.java
@@ -45,6 +45,7 @@ import static com.hazelcast.aws.AwsProperties.REGION;
 import static com.hazelcast.aws.AwsProperties.SECRET_KEY;
 import static com.hazelcast.aws.AwsProperties.SECURITY_GROUP_NAME;
 import static com.hazelcast.aws.AwsProperties.SERVICE_NAME;
+import static com.hazelcast.aws.AwsProperties.SESSION_TOKEN;
 import static com.hazelcast.aws.AwsProperties.TAG_KEY;
 import static com.hazelcast.aws.AwsProperties.TAG_VALUE;
 
@@ -97,7 +98,7 @@ public class AwsDiscoveryStrategy
     private AwsConfig createAwsConfig() {
         try {
             return AwsConfig.builder()
-                .setAccessKey(getOrNull(ACCESS_KEY)).setSecretKey(getOrNull(SECRET_KEY))
+                .setAccessKey(getOrNull(ACCESS_KEY)).setSecretKey(getOrNull(SECRET_KEY)).setSessionToken(getOrNull(SESSION_TOKEN))
                 .setRegion(getOrDefault(REGION.getDefinition(), null))
                 .setIamRole(getOrNull(IAM_ROLE))
                 .setHostHeader(getOrNull(HOST_HEADER.getDefinition()))

--- a/src/main/java/com/hazelcast/aws/AwsProperties.java
+++ b/src/main/java/com/hazelcast/aws/AwsProperties.java
@@ -39,6 +39,11 @@ enum AwsProperties {
     SECRET_KEY("secret-key", STRING, true),
 
     /**
+     * The STS Token
+     */
+    SESSION_TOKEN("session-token", STRING, true),
+
+    /**
      * The region where your members are running.
      * <p>
      * If not defined, the current instance region is used.


### PR DESCRIPTION
Our developers do not have permanent access and secret keys for connecting to AWS during development, which normally requires the use of AWS SDK Credentials Provider with STS Credentials. However, since Hazelcast AWS does not use the AWS SDK, this cannot be used to solve the issue. To fix this, the session token needs to be passed through as part of the Hazelcast AWS Config. This change enables the passing of the AWS Session Token, which now allows developers to use Hazelcast AWS with STS Credentials.

Implementation details: Added support for session token in Hazelcast AWS Config.